### PR TITLE
Remove dependency on copy-to-clipboard

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,7 +14,6 @@
     "@tauri-apps/api": "^1.5.1",
     "@types/uuid": "^9.0.7",
     "@vicons/fluent": "^0.12.0",
-    "copy-to-clipboard": "^3.3.3",
     "daisyui": "^4.4.11",
     "moment": "^2.29.4",
     "overlayscrollbars": "^2.4.5",

--- a/desktop/src/views/ConnectionsView.vue
+++ b/desktop/src/views/ConnectionsView.vue
@@ -67,7 +67,7 @@ import { Flash20Regular, Dismiss20Regular, Copy20Regular, PlugDisconnected20Regu
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { invoke } from '@tauri-apps/api/tauri'
 import { useToastStore } from '../stores/toast'
-import copy from 'copy-to-clipboard'
+import { writeText } from '@tauri-apps/api/clipboard'
 
 
 export interface Connection {
@@ -110,12 +110,11 @@ const closeConnection = (id: string) => {
 }
 
 const copyLocalLink = (url: string) => {
-    try {
-        copy(url)
+    writeText(url).then((res) => {
         toast.showMessage('success', 'Local link copied!', 5000)
-    } catch {
+    }).catch((err) => {
         toast.showMessage('error', 'Copy failed', 5000)
-    }
+    })
 }
 
 onMounted(() => {


### PR DESCRIPTION
Tauri's built-in clipboard API can handle clipboard events, as shown in [Tauri-clipboard](https://tauri.app/v1/api/js/clipboard/#__docusaurus_skipToContent_fallback). So the dependency on copy-to-clipboard can be removed