### PR TITLE
fix: adjust the popup direction of combobox to adaptive

### DIFF
--- a/desktop/ui/GetStartedView.qml
+++ b/desktop/ui/GetStartedView.qml
@@ -127,6 +127,26 @@ Item {
 
             model: daemon.availableAddresses
             width: 360
+
+            popup.y: {
+                // Get the absolute coordinates of the combo box in the window
+                var absoluteY = addressCombo.mapToGlobal(0, 0).y;
+                // Get window height
+                var windowHeight = Window.window ? Window.window.height : Screen.height;
+                // Calculate the available space below
+                var spaceBelow = windowHeight - (absoluteY + height);
+                // Calculate the available space above
+                var spaceAbove = absoluteY;
+                // Default height of popup
+                var popupHeight = popup.height;
+
+                // If there is not enough space below and enough space above, pop it up
+                if (spaceBelow < popupHeight && spaceAbove >= popupHeight) {
+                    return -popupHeight;
+                }
+                // By default, it will pop up downwards
+                return height;
+            }
         }
 
         TextField {


### PR DESCRIPTION
## System information for bug reporting and debugging

```
System	: Windows 11 Version 23H2
CPU	: x86_64
Kernel	: winnt-10.0.22631
ABI	: x86_64-little_endian-llp64
WSRX	: 0.2.31.g195a598
Machine	: LAPTOP-5HC8OVNN-cb79d211-728d-4bbb-b01d-c7f676d5c40d
```

## Description

### Original

When clicking on combobox, it will first attempt to pop up menu items downwards. If there is not enough space below, it will switch to popping up upwards, which will cause a slight flicker.

<video src="https://github.com/user-attachments/assets/dfb21c9a-b335-4ac1-9307-69acd3de3094" autoplay></video>

### Modification plan

- First calculate the distance between the current combobox and the bottom of the window. 
- If it is greater than the height of the pop-up box, it will pop up downwards. 
- Otherwise, it will pop up upwards

<video src="https://github.com/user-attachments/assets/1a73b5f8-844c-46ec-86e6-04cb8e0d531c" autoplay></video>

