### PR TITLE
:bug: fix wildcard route

### DIFF
--- a/crates/wsrx/src/cli/serve.rs
+++ b/crates/wsrx/src/cli/serve.rs
@@ -81,7 +81,7 @@ fn build_router(secret: Option<String>) -> axum::Router {
                 Ok(next.run(req).await)
             },
         ))
-        .route("/traffic/*key", get(process_traffic).options(ping))
+        .route("/traffic/{*key}", get(process_traffic).options(ping))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|request: &Request<Body>| {


### PR DESCRIPTION
axum has changed wildcard route expression at v0.8: https://github.com/tokio-rs/axum/discussions/3204

If you try to compile wsrx v0.5.3 and run `serve` command, the program will panic:

```log
➜  ~ wsrx serve
thread 'main' panicked at wsrx-0.5.3/src/cli/serve.rs:84:10:
Path segments must not start with `*`. For wildcard capture, use `{*wildcard}`. If you meant to literally match a segment starting with an asterisk, call `without_v07_checks` on the router.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```